### PR TITLE
 Make Jupiter Swap API configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Notifications (optional): Example of using a notification system
 
 A Solana Components Repo will be released in the near future to house a common components library.
 
+### Using custom Swap API urls
+
+
+You can set custom URLs via the configuration for any self-hosted Jupiter APIs, like the [V6 Swap API](https://station.jup.ag/docs/apis/self-hosted) or [QuickNode's Metis API](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api). Here is an example
+
+```
+JUP_SWAP_API=https://metis.quiknode.pro/D3ADB33F/quote
+```
+
 ### Structure
 
 The scaffold project structure may vary based on the front end framework being utilized. The below is an example structure for the Next js Scaffold.

--- a/src/lib/query/use-jup-quote.ts
+++ b/src/lib/query/use-jup-quote.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-const QUOTE_API_BASE = "https://quote-api.jup.ag/v6/quote";
+const QUOTE_API_BASE = process.env.JUP_SWAP_API || "https://public.jupiterapi.com/quote";
 
 type UseJupQueryArgs = {
   inputMint: string;


### PR DESCRIPTION
1. Makes the Jupiter Swap V6 API base URL configurable.
2. Changes default URL to URL with higher rate limits.
3. Updates the README.